### PR TITLE
Functional xmllint check

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: check-xmllint
+  name: Running xmllint to check XML files format
+  description: Formats XML files
+  entry: check-xmllint
+  language: script
+  types_or: [xml]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,11 @@
   entry: check-xmllint
   language: script
   types_or: [xml]
+
+- id: format-xmllint
+  name: Running xmllint to reformat XML files to match xmllint
+  description: Formats XML files
+  entry: check-xmllint
+  args: [-i]
+  language: script
+  types_or: [xml]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,14 +1,14 @@
-- id: check-xmllint
-  name: Running xmllint to check XML files format
-  description: Formats XML files
+- id: format-xmllint
+  name: Formats XML files
+  description: Format XML files to match xmllint --format option
   entry: check-xmllint
+  args: [-i]
   language: script
   types_or: [xml]
 
-- id: format-xmllint
-  name: Running xmllint to reformat XML files to match xmllint
-  description: Formats XML files
+- id: check-xmllint
+  name: Check XML files formatting
+  description: Check that XML files format matches xmllint --format option
   entry: check-xmllint
-  args: [-i]
   language: script
   types_or: [xml]

--- a/README.md
+++ b/README.md
@@ -1,35 +1,30 @@
 # xmllint pre-commit hook
 
 This is a hook feeding all files through xmllint. '*xmllint*' command is
-assumed to exists in command path (*please use alias if you don't want to have command in a path, or modify the hook*).
+assumed to exists in command path (*please use alias if you don't want to have
+command in a path, or modify the hook*).
 
 ## Operation
 
-*check-xmllint* hook runs xmllint --format and fails if any modified file doesn't match xmllint --format output.
-
 *format-xmllint* overwrites malformed files with reformated file.
+
+~check-xmllint~ hook runs xmllint --format and fails if any modified file
+doesn't match xmllint --format output. We don't advise to use that option.
 
 ## Setting up
 
-Add following to .pre-commit-config.yaml in repository you would like to check:
+Create or add following to .pre-commit-config.yaml in repository you would like to check:
 
 ```yaml
+repos:
   - repo: https://github.com/lsst-ts/pre-commit-xmllint
     rev: v1.0.0
     hooks:
-      - id: check-xmllint
+      - id: format-xmllint
 ```
 
 and install the hook:
 
 ```sh
 pre-commit install
-```
-
-## Reformating all xml files
-
-Before setting up xmllint, you can reformat all xml files to match xmllinted output with:
-
-```bash
-pre-commit try-repo https://github.com/lsst-ts/pre-commit-xmllint format-xmllint --verbose --all-files
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # xmllint pre-commit hook
 
-This is a hook feeding all files through xmllint. '*xmllint*' command is
-assumed to exists in command path (*please use alias if you don't want to have
-command in a path, or modify the hook*).
+This is a [pre-commit](https://pre-commit.com) hook feeding all files through
+xmllint. '*xmllint*' command is assumed to exists in command path (*please use
+alias if you don't want to have command in a path, or modify the hook*).
 
 ## Operation
 

--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ and install the hook:
 ```sh
 pre-commit install
 ```
+
+## Reformating all xml files
+
+Before setting up xmllint, you can reformat all xml files to match xmllinted output with:
+
+```bash
+pre-commit try-repo https://github.com/lsst-ts/pre-commit-xmllint format-xmllint --verbose --all-files
+```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ assumed to exists in command path (*please use alias if you don't want to have c
 
 ## Operation
 
-Runs xmllint --format and overwrites reformated file.
+*check-xmllint* hook runs xmllint --format and fails if any modified file doesn't match xmllint --format output.
+
+*format-xmllint* overwrites malformed files with reformated file.
 
 ## Setting up
 

--- a/check-xmllint
+++ b/check-xmllint
@@ -2,16 +2,59 @@
 
 XMLLINT=xmllint
 
+if [ -t 1 ]; then
+  R=$(tput setaf 1)
+  G=$(tput setaf 2)
+  Y=$(tput setaf 3)
+  N=$(tput sgr0)
+fi
+
+args=$(getopt i $*)
+if [ $? -ne 0 ]; then
+  echo "Usage: check-xmllint [-i] <files..>
+  -i overwrite files with xmllint formatted content
+"
+  exit 2
+fi
+set -- $args
+
+inplace=0
+
+while true; do
+  case "$1" in
+    -i)
+      inplace=1
+      ;;
+    --)
+      shift
+      break
+      ;;
+  esac
+  shift
+done
+
 retval=0
 
 for FILE in $*; do
-  echo "Checking XMLLint for $FILE"
-  if ! $XMLLINT --format $FILE | diff - $FILE; then
-    echo "XML check for $FILE: failed"
-    retval=2
+  tmpfile=$(mktemp)
+  if ! $XMLLINT --format $FILE > $tmpfile; then
+      echo "XML check for $FILE: ${R}cannot parse${N}"
   else
-    echo "XML check for $FILE: OK"
+    if ! diff $tmpfile $FILE; then
+      if [ $inplace -eq 0 ]; then
+        echo "XML check for $FILE: ${R}failed${N}"
+        retval=2
+      else
+        tmpfile=$(mktemp)
+        $XMLLINT --format $FILE > $tmpfile
+        cp $tmpfile $FILE
+        echo "XML check for $FILE: ${Y}reformatted${N}"
+      fi
+    else
+      echo "XML check for $FILE: ${G}OK${N}"
+    fi
   fi
+  rm -f $tmpfile
 done
 
 exit $retval

--- a/check-xmllint
+++ b/check-xmllint
@@ -39,6 +39,7 @@ for FILE in $*; do
   tmpfile=$(mktemp)
   if ! $XMLLINT --format $FILE > $tmpfile; then
       echo "XML check for $FILE: ${R}cannot parse${N}"
+      retval=1
   else
     if ! diff $tmpfile $FILE; then
       if [ $inplace -eq 0 ]; then

--- a/check-xmllint
+++ b/check-xmllint
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+XMLLINT=xmllint
+
+retval=0
+
+for FILE in $*; do
+  echo "Checking XMLLint for $FILE"
+  if ! $XMLLINT --format $FILE | diff - $FILE; then
+    echo "XML check for $FILE: failed"
+    retval=2
+  else
+    echo "XML check for $FILE: OK"
+  fi
+done
+
+exit $retval


### PR DESCRIPTION
Allows user to choose between check-xmllint (check only) and format-xmllint
(reformet files) hooks.